### PR TITLE
Update archive zip name to standard across all hvt repo's

### DIFF
--- a/webpack.production.js
+++ b/webpack.production.js
@@ -5,8 +5,9 @@ const archiver = require('archiver');
 const branchName = require('current-git-branch');
 
 const LAMBDA_NAME = 'RecordHandlerFunction';
+const REPO_NAME = `hvt-record-handler`;
 const OUTPUT_FOLDER = './dist'
-const BUILD_VERSION = branchName().replace("/","-");
+const BRANCH_NAME = branchName().replace("/","-");
 
 class BundlePlugin {
   constructor(params) {
@@ -53,17 +54,20 @@ class BundlePlugin {
   }
 };
 
-module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new BundlePlugin({
-      archives: [
-        {
-          inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
-          outputPath: `${OUTPUT_FOLDER}`,
-          outputName: `HVT-${LAMBDA_NAME}-${BUILD_VERSION}`,
-        }
-      ],
-    }),
-  ],
-});
+module.exports = env => {
+  let commit = env ? env.commit ? env.commit : 'local' : 'local' ;
+  return merge(common, {
+    mode: 'production',
+    plugins: [
+      new BundlePlugin({
+        archives: [
+          {
+            inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
+            outputPath: `${OUTPUT_FOLDER}`,
+            outputName: `${REPO_NAME}-${BRANCH_NAME}-${commit}`,
+          }
+        ],
+      }),
+    ],
+  })
+};


### PR DESCRIPTION
- Optionally pass in commit id when building so the zip file
is named correctly through build config files, not through
Jenkinsfile scripts
- Pipeline can now call build command:
`npm run build:prod -- --env.commit=<commit-hash>`
- Ticket #BL-11943