### PR TITLE
Only publish to history topic if availability has changed

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -31,7 +31,6 @@ export const handler = async (event: DynamoDBStreamEvent, context: Context): Pro
     const oldImage: AttributeMap = AWS.DynamoDB.Converter.unmarshall(record.dynamodb.OldImage);
     const newImage: AttributeMap = AWS.DynamoDB.Converter.unmarshall(record.dynamodb.NewImage);
 
-    availabilityHistoryMessages.push(oldImage);
     try {
       availabilityData = extractAvailabilityData(oldImage, newImage);
     } catch (err2) {
@@ -41,6 +40,7 @@ export const handler = async (event: DynamoDBStreamEvent, context: Context): Pro
     const { oldAvailability, newAvailability } = availabilityData;
 
     if (availabilityHasChanged(oldAvailability, newAvailability)) {
+      availabilityHistoryMessages.push(oldImage);
       emailMessages.push(newImage);
     }
   });

--- a/tests/handler/index.test.ts
+++ b/tests/handler/index.test.ts
@@ -69,18 +69,17 @@ describe('Record handler lambda index tests', () => {
     jest.clearAllMocks();
   });
 
-  test('should not publish to the email topic if availability has not changed', async () => {
+  test('should not publish to the email or history topic if availability has not changed', async () => {
     extractAvailabilityDataSpy.mockImplementation(jest.fn()).mockReturnValue(availabilityData);
     jest.spyOn(availability, 'availabilityHasChanged').mockReturnValue(false);
     const publisherSpy = jest.spyOn(publisher, 'publishMessages').mockResolvedValue();
 
     await handler(eventMock, contextMock);
 
-    expect(publisherSpy).toBeCalledTimes(1);
-    expect(publisherSpy).nthCalledWith(1, availabilityHistoryPublishParams, expect.anything());
+    expect(publisherSpy).toBeCalledTimes(0);
   });
 
-  test('should not publish to the email topic if extractAvailabilityData fails', async () => {
+  test('should not publish to the email or history topic if extractAvailabilityData fails', async () => {
     const extractError = new Error('Extract error');
     extractAvailabilityDataSpy.mockImplementation(() => { throw extractError; });
     jest.spyOn(availability, 'availabilityHasChanged').mockReturnValue(true);
@@ -89,18 +88,7 @@ describe('Record handler lambda index tests', () => {
     await handler(eventMock, contextMock);
 
     expect(loggerErrorSpy).toBeCalledWith(extractError.message);
-    expect(publisherSpy).toBeCalledTimes(1);
-    expect(publisherSpy).nthCalledWith(1, availabilityHistoryPublishParams, expect.anything());
-  });
-
-  test('should publish the OldImage to the availability history topic even if availability has not changed', async () => {
-    extractAvailabilityDataSpy.mockImplementation(jest.fn()).mockReturnValue(availabilityData);
-    jest.spyOn(availability, 'availabilityHasChanged').mockReturnValue(false);
-    const publisherSpy = jest.spyOn(publisher, 'publishMessages').mockResolvedValue();
-
-    await handler(eventMock, contextMock);
-
-    expect(publisherSpy).toBeCalledWith(availabilityHistoryPublishParams, expect.anything());
+    expect(publisherSpy).toBeCalledTimes(0);
   });
 
   test('should publish the NewImage to the email topic if availability has changed', async () => {


### PR DESCRIPTION
## Description

- Move pushing to history queue to after the has availability
changed check
- Update tests to reflect change in functionality
- Fixes bug where refreshing the token results in publishing to
the history queue

Related issue: [BL-12091](https://jira.dvsacloud.uk/browse/BL-12091)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added test coverage to the JIRA ticket
- [x] Commit contains the JIRA ticket number